### PR TITLE
Better developing experience (environment path, visual studio support)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ ATS_API_UNITY/fmod_editor.log
 ATS_API_UNITY/ProjectSettings/RiderScriptEditorPersistedState.asset
 ATS_API_Unity/Assets/ATS
 ATS_API_Unity/Assets/ATS.meta
+
+# Config file (Environment Path)
+Directory.Path.props

--- a/ATS_API/ATS_API.csproj
+++ b/ATS_API/ATS_API.csproj
@@ -7,7 +7,6 @@
         <Version>3.2.1</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>latest</LangVersion>
-        <StormPath>C:\Program Files (x86)\Steam\steamapps\common\Against the Storm</StormPath>
         <BepInExPath>$([System.Environment]::GetFolderPath(SpecialFolder.ApplicationData))/Thunderstore Mod Manager/DataFolder/AgainstTheStorm/profiles/Default/BepInEx</BepInExPath>
     </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="Directory.Path.props" />
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,7 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk">
-    <!-- Other settings and configurations -->
-
-    <Target Name="PostBuild" AfterTargets="AfterBuild">
-<!--        <Exec Condition="'$(MSBuildProjectName)'=='ExampleMod'" Command='call "$(StormPath)/Against The Storm.exe"' IgnoreExitCode="true"/>-->
-    </Target>
-</Project>

--- a/ExampleMod/ExampleMod.csproj
+++ b/ExampleMod/ExampleMod.csproj
@@ -7,7 +7,6 @@
         <Version>3.1.0</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>latest</LangVersion>
-        <StormPath>C:\Program Files (x86)\Steam\steamapps\common\Against the Storm</StormPath>
         <BepInExPath>$([System.Environment]::GetFolderPath(SpecialFolder.ApplicationData))/Thunderstore Mod Manager/DataFolder/AgainstTheStorm/profiles/Default/BepInEx</BepInExPath>
     </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -27,3 +27,16 @@ If you are wanting to get started with modding the game then this mod can be cop
 If you require help with a mod, have ideas you want to share, want to report a problem or want to contribute to the modding scene you can join our discord.
 
 https://discord.com/invite/ZfVWG86gsJ
+
+## Build
+
+Before opening the solution, you need to create a file named `Directory.Path.props` in the root of the repository. This file should specify the path to your ATS game executable. Below is an example of how to set it up (the content of this file):
+```xml
+<Project>
+  <PropertyGroup>
+    <StormPath>C:\Program Files (x86)\Steam\steamapps\common\Against the Storm</StormPath>
+  </PropertyGroup>
+</Project>
+```
+Make sure to replace the StormPath value with the actual installation path of your game.
+


### PR DESCRIPTION
# Modification
- `StormPath` is removed from two `csproj` files, the developer now need to define their path in `Directory.Path.props`
- Remove `Directory.Build.targets`, this will cause `circular dependency` error in visual studio 2022.
- Add a build instruction in the readme file

About the file structure
- Path is defined in `Directory.Path.props` (is ignored by git)
- `Directory.Build.props` refer and include the file `Directory.Path.props`
- `Directory.Build.props` impacts all `.csproj` files

I have already tested them on Visual Studio 2022 and Rider 2024.3.3